### PR TITLE
Add support for running as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,28 @@
 FROM ubuntu:latest
-RUN mkdir -p /root/.config
-RUN mkdir -p /root/Data
-RUN mkdir -p /root/Data/ofscraper
-RUN mkdir -p /root/ofscraper
-WORKDIR /root
-COPY / ./ofscraper
-WORKDIR ./ofscraper
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get install curl python3.10 pip git python3.10-venv -y
+
+RUN apt-get update -y \
+    && apt-get upgrade -y \
+    && apt-get install curl python3.10 pip git -y
+
+ENV POETRY_HOME=/usr/local/share/pypoetry
+ENV POETRY_VIRTUALENVS_CREATE=false
 RUN curl -sSL https://install.python-poetry.org | python3 -
-RUN python3.10 -m venv .venv
+
+RUN mkdir -p /ofscraper/app
+WORKDIR /ofscraper/app
+COPY /pyproject.toml ./
+COPY /poetry.lock ./
+COPY /.git ./.git
+
 RUN pip install dunamai
-RUN /root/.local/bin/poetry version $(dunamai from git --format "{base}" --pattern "(?P<base>\d+\.\d+\.\d+)")
-RUN /root/.local/bin/poetry install
-ENV PATH="$PATH:/root/ofscraper/.venv/bin/"
-WORKDIR /root
-ENTRYPOINT ["/root/ofscraper/.venv/bin/ofscraper"]
+
+COPY / .
+
+RUN /usr/local/share/pypoetry/bin/poetry version $(dunamai from git --format "{base}" --pattern "(?P<base>\d+\.\d+\.\d+)")
+RUN /usr/local/share/pypoetry/bin/poetry install
+
+WORKDIR /ofscraper
+
+ENTRYPOINT ["ofscraper", "--config", "/ofscraper/config/config.json"]
+
+VOLUME /ofscraper/config /ofscraper/bin /ofscraper/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,29 @@
-version: '3.3'
+version: '3'
+
+volumes:
+  bin:
+  config:
+  data:
+
 services:
-  datawhores:
+  ofscraper:
     container_name: ofscraper
     image: datawhores/of-scraper:main
-    #we have to docker exec
-    entrypoint: ["/bin/bash"]
+    restart: unless-stopped
     volumes:
-    #change the host mountpoint
-      - /home/john/.config/ofscraper:/root/.config/ofscraper
-    command: ["-c","sleep infinity"]
-    environment:
-      - PUID=1000
-      - PGID=1000
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
+      - bin:/ofscraper/bin
+      - config:/ofscraper/config
+      - data:/ofscraper/data
+    user: 1000:1000
+    stdin_open: true
+    tty: true
+    
+    # use the following two lines if you want to interact with the script manually.
+    # bring the container up with `docker compose up -d` and then run it with
+    # `docker compose exec -it ofscraper ofscraper --config /ofscraper/config/config.json`
+    entrypoint: "/bin/bash"
+    command: "-c sleep infinity"
 
-#docker exec ofscraper ofscraper 
-
-      
-
-      
+    # alternatively, if you want the script to run automatically with a set or arguments,
+    # comment out the lines above and instead do something like:
+    # command: "--username ALL --posts all"


### PR DESCRIPTION
This seems to work? The only catch here is that you have to run it with `ofscraper --config /ofscraper/config/config.json` because the python code expects the config file to be in home by default.

Also I reorganized the Dockerfile a bit to help with caching. Copying in the `.git` folder is kinda meh, but it works so...

Also, I found a bug where if you define a config path per the above example but use a relative dir, it breaks downloads.