### PR TITLE
rework Dockerfile to speed up fixuid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,36 @@
-FROM ubuntu:latest
-RUN apt-get update -y \
-    && apt-get upgrade -y \
-    && apt-get install curl python3.11 pip git python3.11-venv -y
+FROM python:3.11 as base
+
+ENV PYTHONFAULTHANDLER=1 \
+    PYTHONHASHSEED=random \
+    PYTHONUNBUFFERED=1
+
+ENV PIP_DEFAULT_TIMEOUT=100 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    POETRY_VERSION=1.7.1
+
+WORKDIR /app
+
+RUN python -m ensurepip --upgrade
+
+FROM base as builder
+
+RUN pip3 install "poetry==$POETRY_VERSION"
+RUN python -m venv /venv
+
+COPY poetry.lock pyproject.toml ./
+RUN poetry export -f requirements.txt | /venv/bin/pip --no-cache-dir install -r /dev/stdin
+
+COPY . .
+RUN poetry build && /venv/bin/pip install dist/*.whl
+
+
+FROM base as final
+
+COPY --from=builder /venv /venv
+
+ENV PATH="/venv/bin:${PATH}" \
+    VIRTUAL_ENV="/venv"
 
 RUN addgroup --gid 1000 ofscraper && \
     adduser --uid 1000 --ingroup ofscraper --home /home/ofscraper --shell /bin/sh --disabled-password --gecos "" ofscraper
@@ -12,24 +41,7 @@ RUN USER=ofscraper && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid && \
     mkdir -p /etc/fixuid && \
-    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+    printf "user: $USER\ngroup: $GROUP\npaths:\n  - /home/ofscraper/\n" > /etc/fixuid/config.yml
 USER ofscraper:ofscraper
 
-ENV POETRY_HOME=/home/ofscraper/local/share/pypoetry
-RUN mkdir -p /home/ofscraper/app
-WORKDIR /home/ofscraper/app
-COPY /pyproject.toml ./ 
-COPY --chown=ofscraper:ofscraper /poetry.lock ./
-COPY --chown=ofscraper:ofscraper /.git ./.git
-COPY --chown=ofscraper:ofscraper / .
-RUN rm -rf .venv
-RUN curl -sSL https://install.python-poetry.org | python3.11 -
-
-USER ofscraper:ofscraper
-RUN python3.11 -m venv .venv
-RUN ${POETRY_HOME}/bin/poetry install --with build
-RUN ${POETRY_HOME}/bin/poetry version $(${POETRY_HOME}/bin/poetry run dunamai from git --format "{base}" --pattern "(?P<base>\d+\.\d+\.\w+)")
-
-ENV PATH="$PATH:/home/ofscraper/app/.venv/bin/"
-WORKDIR /home/ofscraper/app
 ENTRYPOINT ["fixuid","-q"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,28 @@
 version: "3"
 
-volumes:
-  bin:
-  config:
-  data:
-
 services:
   ofscraper:
     container_name: ofscraper
     image: datawhores/of-scraper:latest
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
+    # specify the uid and gid you want to use, if not 1000:1000
     user: "${UID:-1000}:${GID:-1000}"
     volumes:
-      # #change the host mountpoint
-      - /home/john/.config/ofscraper:/root/.config/ofscraper
+      # change the host path to wherever your config dir/file is
+      - /home/john/.config/ofscraper:/ofscraper/.config/ofscraper
+      # you can use any path for the following, so long as
+      # you update your config file accordingly, and ensure that
+      # permissions are correct
+      - ./bin:/home/ofscraper/bin
     stdin_open: true # docker run -i
     tty: true # docker run -t
-    # use the following two lines if you want to interact with the script manually.
-    # bring the container up with `docker compose up -d` and then run it with
-    # `docker compose exec -it ofscraper ofscraper --config /ofscraper/config/config.json`
-    entrypoint: ["/bin/bash"]
-    command: ["-c", "sleep infinity"]
 
-    # alternatively, if you want the script to run automatically with a set or arguments,
-    # comment out the lines above and instead do something like:
+    # use the following command if you want to interact with the script.
+    command: ["/bin/bash", "-c", "sleep infinity"]
+    # bring the container up with `docker compose up -d` and then
+    # run it with something like:
+    # `docker compose exec -it ofscraper ofscraper`
+    # (optionally, you can specify additional arguments)
+
+    # alternatively, if you want the script to run automatically with a set of arguments,
+    # use something like the following command instead:
     # command: "ofscraper --username ALL --posts all"


### PR DESCRIPTION
fixuid is currently crazy slow on startup because it goes through the whole venv and the various caches associated with the python setup.

This way, it is nearly instant since it only needs to chown a few files. Also, switching to the `python` base image speeds up build time significantly, and probably reduces image size (though I haven't confirmed this)