### PR TITLE
Fix cache.get default values

### DIFF
--- a/ofscraper/api/archive.py
+++ b/ofscraper/api/archive.py
@@ -324,7 +324,7 @@ Setting initial archived scan date for {username} to {arrow.get(after).format('Y
 def set_check(unduped, model_id, after):
     if not after:
         newCheck = {}
-        for post in cache.get(f"archived_check_{model_id}", []) + list(
+        for post in cache.get(f"archived_check_{model_id}", default=[]) + list(
             unduped.values()
         ):
             newCheck[post["id"]] = post

--- a/ofscraper/api/messages.py
+++ b/ofscraper/api/messages.py
@@ -300,7 +300,7 @@ Setting initial message scan date for {username} to {arrow.get(after).format('YY
 def set_check(unduped, model_id, after):
     if not after:
         newCheck = {}
-        for post in cache.get(f"message_check_{model_id}", []) + list(unduped.values()):
+        for post in cache.get(f"message_check_{model_id}", default=[]) + list(unduped.values()):
             newCheck[post["id"]] = post
         cache.set(
             f"message_check_{model_id}",

--- a/ofscraper/api/paid.py
+++ b/ofscraper/api/paid.py
@@ -111,7 +111,7 @@ async def get_paid_posts(username, model_id):
 
 def set_check(unduped, model_id):
     newCheck = {}
-    for post in cache.get(f"purchased_check_{model_id}", []) + list(unduped.values()):
+    for post in cache.get(f"purchased_check_{model_id}", default=[]) + list(unduped.values()):
         newCheck[post["id"]] = post
     cache.set(
         f"purchased_check_{model_id}",

--- a/ofscraper/api/profile.py
+++ b/ofscraper/api/profile.py
@@ -45,7 +45,7 @@ def scrape_profile(username: Union[int, str]) -> dict:
 
 def scrape_profile_helper(c, username: Union[int, str]):
     attempt.set(0)
-    data = cache.get(f"username_{username}", None)
+    data = cache.get(f"username_{username}", default=None)
     log.trace(f"username date: {data}")
     if data and not read_args.retriveArgs().update_profile:
         return data
@@ -91,7 +91,7 @@ def scrape_profile_helper(c, username: Union[int, str]):
 
 async def scrape_profile_helper_async(c, username: Union[int, str]):
     attempt.set(0)
-    data = cache.get(f"username_{username}", None)
+    data = cache.get(f"username_{username}", default=None)
     log.trace(f"username date: {data}")
     if data and not read_args.retriveArgs().update_profile:
         return data

--- a/ofscraper/api/timeline.py
+++ b/ofscraper/api/timeline.py
@@ -323,7 +323,7 @@ Setting initial timeline scan date for {username} to {arrow.get(after).format('Y
 def set_check(unduped, model_id, after):
     if not after:
         newCheck = {}
-        for post in cache.get(f"timeline_check_{model_id}", []) + list(
+        for post in cache.get(f"timeline_check_{model_id}", default=[]) + list(
             unduped.values()
         ):
             newCheck[post["id"]] = post

--- a/ofscraper/utils/separate.py
+++ b/ofscraper/utils/separate.py
@@ -26,7 +26,7 @@ def seperate_avatars(data):
 def seperate_avatar_helper(ele):
     # id for avatar comes from xxh32 of url
     if ele.postid and ele.responsetype == "profile":
-        value = cache.get(ele.postid, False)
+        value = cache.get(ele.postid, default=False)
         cache.close()
         return value
     return False


### PR DESCRIPTION
The cache.get function expects the default to be passed as a keyword argument.  However, numerous places passed it as a positional argument instead.  This causes certain instances to break when cache is disabled.  For example, `cache.get(f"message_check_{model_id}", []) + list(unduped.values())` results in `TypeError: unsupported operand type(s) for +: 'NoneType' and 'list'`