### PR TITLE
fix invalid escape sequence warning in regex strings

### DIFF
--- a/ofscraper/utils/args/helpers/type.py
+++ b/ofscraper/utils/args/helpers/type.py
@@ -40,7 +40,7 @@ def posttype_helper(x):
     )
     if isinstance(x, str):
         x = re.split(",| ", x)
-        x = list(map(lambda x: re.sub("[^a-zA-Z-\*\+]", "", str.title(x)), x))
+        x = list(map(lambda x: re.sub(r"[^a-zA-Z-\*\+]", "", str.title(x)), x))
     if len(list(filter((lambda y: y not in choices and y[1:] not in choices), x))) > 0:
         raise argparse.ArgumentTypeError(
             "error: argument -o/--posts: invalid choice: (choose from 'highlights', 'all', 'archived', 'messages', 'timeline', 'pinned', 'stories', 'purchased','profile','labels')"
@@ -67,7 +67,7 @@ def download_helper(x):
     )
     if isinstance(x, str):
         x = re.split(",| ", x)
-        x = list(map(lambda x: re.sub("[^a-zA-Z\*\+]", "", str.title(x)), x))
+        x = list(map(lambda x: re.sub(r"[^a-zA-Z\*\+]", "", str.title(x)), x))
     if len(list(filter((lambda y: y not in choices and y[1:] not in choices), x))) > 0:
         raise argparse.ArgumentTypeError(
             "error: argument -da/--download-area: invalid choice: (choose from 'highlights', 'all', 'archived', 'messages', 'timeline', 'pinned', 'stories', 'purchased','profile','labels')"
@@ -80,7 +80,7 @@ def like_helper(x):
     choices = set(["All", "Archived", "Timeline", "Pinned", "Labels"])
     if isinstance(x, str):
         x = re.split(",| ", x)
-        x = list(map(lambda x: re.sub("[^a-zA-Z-\*\+]", "", str.title(x)), x))
+        x = list(map(lambda x: re.sub(r"[^a-zA-Z-\*\+]", "", str.title(x)), x))
     if len(list(filter((lambda y: y not in choices and y[1:] not in choices), x))) > 0:
         raise argparse.ArgumentTypeError(
             "error: argument -la/--like-area: invalid choice: (choose from 'all', 'archived', 'timeline', 'pinned','labels')"
@@ -93,7 +93,7 @@ def post_check_area(x):
     choices = set(["All", "Archived", "Timeline", "Pinned", "Labels"])
     if isinstance(x, str):
         x = re.split(",| ", x)
-        x = list(map(lambda x: re.sub("[^a-zA-Z-\*\+]", "", str.title(x)), x))
+        x = list(map(lambda x: re.sub(r"[^a-zA-Z-\*\+]", "", str.title(x)), x))
     if len(list(filter((lambda y: y not in choices and y[1:] not in choices), x))) > 0:
         raise argparse.ArgumentTypeError(
             "error: argument -la/--like-area: invalid choice: (choose from 'all', 'archived', 'timeline', 'pinned','labels')"


### PR DESCRIPTION
![image](https://github.com/datawhores/OF-Scraper/assets/91510725/381d738f-eed2-40d7-b185-c8f2146c1f12)

Changing to a raw string so python doesn't try to interpolate `\*` as an escape sequence