### PR TITLE
Allow docker image to be multiarchitecture

### DIFF
--- a/.github/workflows/docker-daily.yml
+++ b/.github/workflows/docker-daily.yml
@@ -61,6 +61,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta2.outputs.tags }}
           labels: ${{ steps.meta2.outputs.labels }}
           cache-to: type=gha,mode=max
@@ -114,6 +115,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-to: type=gha,mode=max

--- a/.github/workflows/release_bundler.yml
+++ b/.github/workflows/release_bundler.yml
@@ -671,6 +671,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: |
             datawhores/of-scraper:${{ inputs.version }}
             datawhores/of-scraper:latest
@@ -756,6 +757,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/datawhores/of-scraper:${{ inputs.version }}
             ghcr.io/datawhores/of-scraper:latest
@@ -811,6 +813,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: |
             datawhores/of-scraper:${{ inputs.version }}
 
@@ -895,6 +898,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/datawhores/of-scraper:${{ inputs.version }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11 as base
+FROM python:3.11 AS base
 
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
@@ -13,7 +13,11 @@ WORKDIR /app
 
 RUN python -m ensurepip --upgrade
 
-FROM base as builder
+RUN apt-get update && apt-get -y dist-upgrade
+
+RUN apt-get update && apt-get install ffmpeg cmake wget -y
+
+FROM base AS builder
 
 RUN pip3 install "poetry==$POETRY_VERSION"
 RUN python -m venv /venv
@@ -26,9 +30,48 @@ RUN  pip install dunamai
 RUN poetry version $(poetry run dunamai from git --format "{base}" --pattern "(?P<base>\d+\.\d+\.\w+)")
 RUN poetry build && /venv/bin/pip install dist/*.whl
 
-FROM base as final
+FROM base AS bento4
+
+RUN wget https://github.com/axiomatic-systems/Bento4/archive/refs/tags/v1.6.0-641.tar.gz
+
+RUN tar -xvf v1.6.0-641.tar.gz
+
+WORKDIR /app/Bento4-1.6.0-641/
+
+RUN mkdir cmakebuild
+
+WORKDIR /app/Bento4-1.6.0-641/cmakebuild
+
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local ..
+
+RUN make -j4
+
+RUN make install
+
+FROM base AS final
+
+ARG TARGETPLATFORM
+ARG BUILDARCH
 
 COPY --from=builder /venv /venv
+
+RUN mkdir -p /temp_usr_local
+
+COPY --from=bento4 /app/Bento4-1.6.0-641/cmakebuild/install_manifest.txt /app/install_manifest.txt
+
+COPY --from=bento4 /usr/local /temp_usr_local
+
+RUN while read -r line; do \
+        temp_line="/temp_usr_local${line#/usr/local}"; \
+        dir=$(dirname "$line"); \
+        mkdir -p "$dir"; \
+        cp --preserve=all "$temp_line" "$line"; \
+    done < /app/install_manifest.txt
+
+
+RUN rm -f /app/install_manifest.txt
+
+RUN rm -rf /temp_usr_local
 
 ENV PATH="/venv/bin:${PATH}" \
     VIRTUAL_ENV="/venv"
@@ -38,7 +81,8 @@ RUN addgroup --gid 1000 ofscraper && \
 
 RUN USER=ofscraper && \
     GROUP=ofscraper && \
-    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.5.1/fixuid-0.5.1-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - && \
+    LATEST_VERSION=$(curl -s https://api.github.com/repos/boxboat/fixuid/releases/latest | grep "tag_name"| cut -d'v' -f2 | cut -d'"' -f1) && \
+    curl -SsL "https://github.com/boxboat/fixuid/releases/latest/download/fixuid-$LATEST_VERSION-linux-$BUILDARCH.tar.gz" | tar -C /usr/local/bin -xzf - && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid && \
     mkdir -p /etc/fixuid && \


### PR DESCRIPTION
This pull request tells the docker builds to generate both amd64 and arm64 builds.
It also has ffmpeg, bento4, and the latest fixuid bundled in.