### PR TITLE
fix: schema for script_options, bug in post_script

### DIFF
--- a/ofscraper/utils/config/data.py
+++ b/ofscraper/utils/config/data.py
@@ -293,8 +293,8 @@ def get_post_script(config=None):
         val = config.get("post_script")
     elif config.get("advanced_options", {}).get("post_script") is not None:
         val = config.get("advanced_options", {}).get("post_script")
-    elif config.get("scripts", {}).get("post_download_script") is not None:
-        val = config.get("scripts", {}).get("post_download_script")
+    elif config.get("scripts", {}).get("post_script") is not None:
+        val = config.get("scripts", {}).get("post_script")
     elif config.get("script_options", {}).get("post_script") is not None:
         val = config.get("script_options", {}).get("post_script")
     return val if val is not None else constants_attr.getattr("POST_SCRIPT_DEFAULT")

--- a/ofscraper/utils/config/schema.py
+++ b/ofscraper/utils/config/schema.py
@@ -65,7 +65,7 @@ def get_current_config_schema(config: dict = None) -> dict:
             "default_user_list": data.get_default_userlist(config=config),
             "default_black_list": data.get_default_blacklist(config=config),
         },
-        "scripts_options": {
+        "script_options": {
             "post_download_script": data.get_post_download_script(config=config),
             "post_script": data.get_post_script(config=config),
         },


### PR DESCRIPTION
the schema was using `scripts_options` but the rest of the code uses `script_options`. Updated schema to match.

Also, one of the blocks in `get_post_script` was actually checking for `post_download_script`