### PR TITLE
Update file_cleanup to handle backslashes as underscores

### DIFF
--- a/ofscraper/classes/of/base.py
+++ b/ofscraper/classes/of/base.py
@@ -34,7 +34,8 @@ class base:
     def file_cleanup(self, text):
         text = str(text)
         text = re.sub("<[^>]*>", "", text)
-        text = re.sub('[\n<>:"/\|?*:;]+', "", text)
+        text = re.sub("[/\\]", "_", text)
+        text = re.sub('[\n<>:"\|?*:;]+', "", text)
         text = re.sub("-+", "_", text)
         text = re.sub(" +", " ", text)
         text = re.sub(" ", settings.get_settings().space_replacer, text)


### PR DESCRIPTION
Currently, the script does not handle backslashes in post text, which causes a FileNotFound error when processed. I suggest replacing them to prevent path issues. I chose to replace backslashes (as well as forward slashes) with underscores to improve readability based on the original grammatical intent instead of simply deleting them.