### PR TITLE
fix: add copyfile fallback to prevent EPERM crash on backup

### DIFF
--- a/ofscraper/utils/paths/manage.py
+++ b/ofscraper/utils/paths/manage.py
@@ -28,7 +28,13 @@ def copy_path(source, dst):
         logging.getLogger("shared").debug("failed to copy with copy2 using copy")
         logging.getLogger("shared").traceback_(e)
         logging.getLogger("shared").traceback_(traceback.format_exc())
-        shutil.copy(source, dst)
+        try:
+            shutil.copy(source, dst)
+        except OSError:
+            logging.getLogger("shared").debug(
+                "failed to copy with copy, falling back to copyfile"
+            )
+            shutil.copyfile(source, dst)
     except Exception as e:
         raise e
 


### PR DESCRIPTION
## Critical: Silent scrape failure on restricted filesystems

### Problem

On filesystems where `chmod` is restricted (ZFS with NFSv4 ACLs, certain Docker bind mounts, NFS), `copy_path()` in `manage.py` crashes with `PermissionError: [Errno 1] Operation not permitted`.

The crash occurs during DB backup creation (`create_backup` → `copy_path`), which runs before any post/media processing. This means **the entire scrape is silently skipped** — no posts are fetched, no media is downloaded — but ofscraper exits with code 0, completely masking the failure.

The root cause: `shutil.copy2` fails on `copystat` → `chmod`, falls back to `shutil.copy`, which also fails on `copymode` → `chmod`. The uncaught exception from the fallback propagates up and kills media processing.

### Fix

Add `shutil.copyfile` as a final fallback. The fallback chain becomes:

1. `copy2` — copies data + timestamps + permissions *(normal POSIX systems)*
2. `copy` — copies data + permissions *(if timestamps fail)*
3. `copyfile` — copies data only *(if chmod fails with EPERM)*

The file data is successfully copied in all cases. Only the permission metadata step differs.

### Impact

- **Standard POSIX systems**: No change — `copy2` succeeds on the first try
- **Affected systems**: Backup copy is created successfully (data-only), scrape proceeds normally instead of silently failing

### Environment

Reproduced on TrueNAS Scale (ZFS) running ofscraper 3.13.13 in Docker. The container's uid cannot `chmod` files on the ZFS-backed bind mount. This affected every scheduled scrape, silently dropping all downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)