### PR TITLE
Fix --no-api-cache / --redownload cache bypass for Messages/Timeline/Archive/Streams

### DIFF
--- a/ofscraper/data/api/archive.py
+++ b/ofscraper/data/api/archive.py
@@ -59,7 +59,7 @@ async def get_archived_posts(model_id, username, c=None, post_id=None):
 
 
 async def get_oldarchived(model_id, username):
-    if not settings.get_settings().api_cache_disabled:
+    if not settings.get_settings().api_cached_disabled:
         oldarchived = await get_archived_post_info(model_id=model_id, username=username)
     else:
         oldarchived = []

--- a/ofscraper/data/api/messages.py
+++ b/ofscraper/data/api/messages.py
@@ -62,7 +62,7 @@ async def get_messages(model_id, username, c=None, post_id=None):
 
 
 async def get_old_messages(model_id, username):
-    if not settings.get_settings().api_cache_disabled:
+    if not settings.get_settings().api_cached_disabled:
         oldmessages = await get_messages_post_info(model_id=model_id, username=username)
     else:
         oldmessages = []

--- a/ofscraper/data/api/streams.py
+++ b/ofscraper/data/api/streams.py
@@ -60,7 +60,7 @@ async def get_streams_posts(model_id, username, c=None, post_id=None):
 
 
 async def get_oldstreams(model_id, username):
-    if not settings.get_settings().api_cache_disabled:
+    if not settings.get_settings().api_cached_disabled:
         oldstreams = await get_streams_post_info(model_id=model_id, username=username)
     else:
         oldstreams = []

--- a/ofscraper/data/api/timeline.py
+++ b/ofscraper/data/api/timeline.py
@@ -117,7 +117,7 @@ async def process_tasks(generators):
 
 
 async def get_oldtimeline(model_id, username):
-    if not settings.get_settings().api_cache_disabled:
+    if not settings.get_settings().api_cached_disabled:
         oldtimeline = await get_timeline_posts_info(
             model_id=model_id, username=username
         )


### PR DESCRIPTION
## Summary

Fixes a cache flag typo that prevented `--no-api-cache` / `--redownload` from bypassing API cache seeding in several content fetchers.

## Problem

When running CLI commands like:

```bash
ofscraper --action download --username <username> --download-area Messages --redownload
```

the run still used cached post info in some API paths, which could anchor scraping to older records and miss newer content.

## Root Cause

`merged_settings()` defines the flag as:

- `api_cached_disabled`

But these modules were checking:

- `api_cache_disabled` (missing `d`)

So the no-cache condition was never triggered in those paths.

## Changes

Updated cache checks from `api_cache_disabled` to `api_cached_disabled` in:

- `ofscraper/data/api/messages.py`
- `ofscraper/data/api/timeline.py`
- `ofscraper/data/api/archive.py`
- `ofscraper/data/api/streams.py`

## Evidence / Repro

From user logs before the fix:

- Arguments showed `no_api_cache=True` and `redownload=True`
- Run still logged e.g. `Messages Cache 348 found`

That behavior is inconsistent with intended no-API-cache mode and indicates the cache bypass condition was not being honored.

## Validation

- Verified all affected files now reference `api_cached_disabled`
- Verified no remaining `api_cache_disabled` checks in `ofscraper/data/api/*.py`
- Bytecode compile check passed for all touched files:

```bash
python -m compileall \
  ofscraper/data/api/messages.py \
  ofscraper/data/api/archive.py \
  ofscraper/data/api/streams.py \
  ofscraper/data/api/timeline.py
```

## Impact

Low-risk, targeted fix:
- No API shape changes
- No DB schema changes
- Only corrects flag lookup to match existing settings model
