### PR TITLE
fix: strip query string from MPD URL before constructing DASH segment URLs

### DIFF
--- a/ofscraper/commands/scraper/actions/download/managers/alt_download.py
+++ b/ofscraper/commands/scraper/actions/download/managers/alt_download.py
@@ -152,8 +152,10 @@ class AltDownloadManager(DownloadManager):
     async def _alt_download_sendreq(self, item, c, ele, placeholderObj):
         try:
             _attempt = self._alt_attempt_get(item)
-            base_url = re.sub("[0-9a-z]*\.mpd$", "", ele.mpd, re.IGNORECASE)
-            url = f"{base_url}{item['origname']}"
+            mpd_path = ele.mpd.split("?")[0]
+            mpd_query = ("?" + ele.mpd.split("?", 1)[1]) if "?" in ele.mpd else ""
+            base_url = re.sub("[0-9a-z]*\.mpd$", "", mpd_path, re.IGNORECASE)
+            url = f"{base_url}{item['origname']}{mpd_query}"
             common_globals.log.debug(
                 f"{get_medialog(ele)} Attempting to download media {item['origname']} with {url}"
             )
@@ -176,8 +178,10 @@ class AltDownloadManager(DownloadManager):
             total = None
             common_globals.log.debug(f"{get_medialog(ele)} resume header {headers}")
             params = get_alt_params(ele)
-            base_url = re.sub("[0-9a-z]*\.mpd$", "", ele.mpd, re.IGNORECASE)
-            url = f"{base_url}{item['origname']}"
+            mpd_path = ele.mpd.split("?")[0]
+            mpd_query = ("?" + ele.mpd.split("?", 1)[1]) if "?" in ele.mpd else ""
+            base_url = re.sub("[0-9a-z]*\.mpd$", "", mpd_path, re.IGNORECASE)
+            url = f"{base_url}{item['origname']}{mpd_query}"
             headers = {"Cookie": f"{ele.hls_header}{auth_requests.get_cookies_str()}"}
             common_globals.log.debug(
                 f"{get_medialog(ele)} [attempt {self._alt_attempt_get(item).get()}/{get_download_retries()}] Downloading media with url  {ele.mpd}"


### PR DESCRIPTION
## Summary

- DASH segment downloads fail when the MPD URL contains a query string (e.g. `?Tag=2`)
- The regex `re.sub("[0-9a-z]*\.mpd$", ...)` in `_alt_download_sendreq` and `_send_req_inner` doesn't match because the `$` anchor expects the string to end with `.mpd`, but it ends with `.mpd?Tag=2`
- This causes the segment URL to be constructed as `...mpd?Tag=2<segment_name>` instead of `.../<segment_name>?Tag=2`, so the CDN returns the XML manifest instead of the video/audio segment
- ofscraper then saves the manifest XML as the "downloaded" file and marks the media as complete with no actual media on disk

## Fix

Split the query string off the MPD URL before applying the regex, then reattach it to the constructed segment URL. Applied in both `_alt_download_sendreq` (logging URL) and `_send_req_inner` (actual request URL).

## Test plan

- [x] Verified fix downloads DASH-protected content that previously failed silently
- [x] Widevine key extraction and ffmpeg decryption both succeed after fix
- [x] Files land on disk with correct size (tested with ~1 GB video)